### PR TITLE
Fix https blocking

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -3,7 +3,7 @@
 <html>
 <head>
   <title>Google Web Components Kit</title>
-  <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Roboto|Source+Code+Pro:400,600">
+  <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto|Source+Code+Pro:400,600">
   <link rel="stylesheet" href="css/app.css">
   <script src="../platform/platform.js"></script>
   <link rel="import" href="../core-icons/core-icons.html">
@@ -82,7 +82,7 @@ var template = document.querySelector('#t');
 template.elements = ELEMENTS;
 
 template.getHost = function(org) {
-  return 'http://' + org + '.github.io';
+  return '//' + org + '.github.io';
 }
 
 template.loadDemo = function(e, detail, sender) {


### PR DESCRIPTION
Demos and docs are broken when pages are accessed via https.

Chrome: [blocked] The page at 'https://googlewebcomponents.github.io/' was loaded over HTTPS, but ran insecure content from 'http://googlewebcomponents.github.io/google-analytics/components/google-analytics/demo.html': this content should also be loaded over HTTPS.

Firefox: Blocked loading mixed active content "http://googlewebcomponents.github.io/google-calendar/components/google-calendar/demo.html"
